### PR TITLE
Fix spearmint-lite.py indexing bug?

### DIFF
--- a/spearmint-lite/spearmint-lite.py
+++ b/spearmint-lite/spearmint-lite.py
@@ -193,7 +193,7 @@ def main_controller(options, args):
         if isinstance(job_id, tuple):
             (job_id, candidate) = job_id
         else:
-            candidate = candidates[job_id,:]
+            candidate = grid[job_id,:]
 
         sys.stderr.write("Selected job %d from the grid.\n" % (job_id))
         if pending.shape[0] > 0:


### PR DESCRIPTION
Chooser.next() returns candidates[best], which is an integer index from the
candidates list that next() receives as an argument.  spearmint-lite.py
constructs populates that argument with indexes into the `grid` variable
rather than its own local `candidates` variable which is a subset of the rows
of `grid`.

Have I got that right?
