### PR TITLE
Removed paragraph referencing Whetlab.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ possible.
 
 Spearmint is the result of a collaboration primarily between machine learning researchers at [Harvard University](https://hips.seas.harvard.edu/) and the [University of Toronto](http://learning.cs.toronto.edu/).
 
-**Soon you'll be able to do your optimization in the cloud with a more powerful, accessible and scalable tool.  Sign up for the private beta at www.whetlab.com**
-
 Dependencies
 ------------
 This package requires:


### PR DESCRIPTION
Whetlab was bought by Twitter in June 2015, and the http://www.whetlab.com website has since gone down.

Closes Issue #48.